### PR TITLE
Fix: Converted t_env to char ** and fixed exit not working properly

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   functions.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: amezoe <amezoe@student.42.fr>              +#+  +:+       +#+        */
+/*   By: sionow <sionow@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 12:31:05 by amezoe            #+#    #+#             */
-/*   Updated: 2025/08/06 01:25:12 by amezoe           ###   ########.fr       */
+/*   Updated: 2025/08/06 22:48:58 by sionow           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,7 @@ char	**create_args(char *args1, char *args2);
 void	fill_cmds(t_cmd **cmds);
 int		cmds_count(t_cmd *cmds);
 void	close_pipes(t_pipeline *pl);
-void	init_pl(t_pipeline *pl, t_cmd *cmds, char **env);
+void	init_pl(t_pipeline *pl, t_cmd *cmds, t_env_var *env_list);
 void	init_pipes(t_pipeline *pl, int num_cmds);
 void	command_redirections(int i, t_pipeline *pl, t_cmd *cmds);
 int		absolute_path(char *cmd);
@@ -60,7 +60,7 @@ int		builtin_check(t_pipeline *pl, t_cmd *cmds);
 void	exec(t_pipeline *pl, t_cmd *cmds, int i);
 void	command_loop(t_pipeline *pl, t_cmd *cmds);
 //void	exec_main(t_cmd *cmds, char **env);
-void	exec_main(t_cmd *cmds, t_env_var *env_list, int *last_exit_status_ptr);
+void exec_main(t_cmd *cmds, t_env_var *env_list);
 
 //free.c
 

--- a/include/structs.h
+++ b/include/structs.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   structs.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: amezoe <amezoe@student.42.fr>              +#+  +:+       +#+        */
+/*   By: sionow <sionow@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 12:29:52 by amezoe            #+#    #+#             */
-/*   Updated: 2025/07/24 14:03:25 by amezoe           ###   ########.fr       */
+/*   Updated: 2025/08/06 22:35:34 by sionow           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,13 +15,6 @@
 
 #include <sys/types.h>
 
-typedef struct s_pipeline
-{
-	char	**env;
-	int		**pipes;
-	pid_t	*pids;
-	int		num_cmds;
-}	t_pipeline;
 
 typedef enum e_token_types
 {
@@ -68,5 +61,12 @@ typedef struct s_cmd
 } t_cmd;
 
 
+typedef struct s_pipeline
+{
+	t_env_var *env;
+	int		**pipes;
+	pid_t	*pids;
+	int		num_cmds;
+}	t_pipeline;
 
 #endif

--- a/src/exec.c
+++ b/src/exec.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: amezoe <amezoe@student.42.fr>              +#+  +:+       +#+        */
+/*   By: sionow <sionow@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/03 17:31:54 by sionow            #+#    #+#             */
-/*   Updated: 2025/08/06 01:40:50 by amezoe           ###   ########.fr       */
+/*   Updated: 2025/08/06 22:55:30 by sionow           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -130,7 +130,7 @@ void	init_pipes(t_pipeline *pl, int num_cmds)
 	}
 }
 
-void	init_pl(t_pipeline *pl, t_cmd *cmds, char **env)
+void	init_pl(t_pipeline *pl, t_cmd *cmds, t_env_var *env_list)
 {
 	pl->num_cmds = cmds_count(cmds);
 	if (pl->num_cmds > 1)
@@ -143,7 +143,7 @@ void	init_pl(t_pipeline *pl, t_cmd *cmds, char **env)
 		perror("pids");
 		exit(1);
 	}
-	pl->env = env;
+	pl->env = env_list;
 }
 
 void	command_redirections(int i, t_pipeline *pl, t_cmd *cmds)
@@ -208,13 +208,15 @@ char	*env_path(t_cmd *cmds)
 void	not_builtin(t_pipeline *pl, t_cmd *cmds)
 {
 	char	*path;
+	char	**env_array;
 
+	env_array = env_list_array(pl->env);
 	if (absolute_path(cmds->args[0]) == 0)
-		execve(cmds->args[0], cmds->args, pl->env);
+		execve(cmds->args[0], cmds->args, env_array);
 	else
 	{
 		path = env_path(cmds);
-		execve(path, cmds->args, pl->env);
+		execve(path, cmds->args, env_array);
 	}
 	perror("execve");
 	exit_free(cmds);
@@ -255,6 +257,8 @@ void	exec(t_pipeline *pl, t_cmd *cmds, int i)
 		exit_free(cmds);
 		exit(error_code);
 	}
+	else
+		exit(error_code);
 }
 
 void	command_loop(t_pipeline *pl, t_cmd *cmds)
@@ -293,14 +297,14 @@ int get_arg_count(char **args) {
 }
 
 
-void exec_main(t_cmd *cmds, t_env_var *env_list, int *last_exit_status_ptr)
+void exec_main(t_cmd *cmds, t_env_var *env_list)
 {
 	t_pipeline	pl;
 	int			i;
 	int			status;
 
 	i = 0;
-	init_pl(&pl, cmds, env);
+	init_pl(&pl, cmds, env_list);
 	command_loop(&pl, cmds);
 	while (i < pl.num_cmds)
 	{

--- a/src/tester.c
+++ b/src/tester.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   tester.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: amezoe <amezoe@student.42.fr>              +#+  +:+       +#+        */
+/*   By: sionow <sionow@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/22 14:17:16 by amezoe            #+#    #+#             */
-/*   Updated: 2025/08/02 23:14:15 by amezoe           ###   ########.fr       */
+/*   Updated: 2025/08/06 22:51:19 by sionow           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -115,7 +115,7 @@ int	main(int ac, char **av, char **envp)
 				//     if (cmd_temp) printf(" ----- PIPE TO NEXT CMD-----\n");
 				// }
 				// <<< CALL EXEC_MAIN WITH THE POINTER TO last_exit_status >>>
-				exec_main(commands, env_list, &last_exit_status); 
+				exec_main(commands, env_list); 
 				free_cmd_list(commands); // Free the command structure after execution
 			}
 			// else


### PR DESCRIPTION
-removed the int last_exit_status from exec_main bcs not needed
-redid my parameters for init_pl that got broken as well as in function
-removed t=same int last_exit_status from tester to make it run
-fixed a line in my exec that was causing rebrandshell not to exit properly on success

pls never again